### PR TITLE
Always use private interface for bootstrapping

### DIFF
--- a/templates/etc/systemd/system/etcd.service.j2
+++ b/templates/etc/systemd/system/etcd.service.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks:False
 {%- macro cluster_hosts() -%}
 {%- for host in groups[etcd_ansible_group] -%}
-{{hostvars[host]['ansible_hostname']}}=https://{{hostvars[host]['ansible_' + etcd_interface].ipv4.address}}:{{etcd_peer_port}}{% if not loop.last %},{% endif %}
+{{hostvars[host]['inventory_hostname']}}=https://{{hostvars[host].ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('private') | first}}:{{etcd_peer_port}}{% if not loop.last %},{% endif %}
 {%- endfor -%} 
 {%- endmacro -%}
 

--- a/templates/etc/systemd/system/etcd.service.j2
+++ b/templates/etc/systemd/system/etcd.service.j2
@@ -1,7 +1,8 @@
 #jinja2: trim_blocks:False
 {%- macro cluster_hosts() -%}
+{% set separator = joiner(',') %}
 {%- for host in groups[etcd_ansible_group] -%}
-{{hostvars[host]['inventory_hostname']}}=https://{{hostvars[host].ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('private') | first}}:{{etcd_peer_port}}{% if not loop.last %},{% endif %}
+{{ separator() }}{{hostvars[host]['inventory_hostname']}}=https://{{hostvars[host].ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('private') | first}}:{{etcd_peer_port}}
 {%- endfor -%} 
 {%- endmacro -%}
 


### PR DESCRIPTION
Specific to our infrastructure.

The role makes the assumption that all etcd hosts will bootstrap on
the same interface. It is not our case, so we force bootstrapping on the
private interface.
I took the opportunity to make it a cleaner loop using separator/joiner pattern.