### PR TITLE
Add discovery-srv for initial cluster setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ etcd_settings:
   "logger": "zap" # Specify ‘zap’ for structured logging or ‘capnslog’.
   "log-outputs": "systemd/journal" # Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd
   "enable-v2": "true" # enable v2 API to stay compatible with previous etcd 3.3.x (needed for flannel e.g.)
+  "discovery-srv": "" # Discovery domain to enable DNS SRV discovery, leave empty to disable. If set, will override initial-cluster.
 
 # Certificate authority and certificate files for etcd
 etcd_certificates:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ etcd_settings:
   "logger": "zap" # Specify ‘zap’ for structured logging or ‘capnslog’.
   "log-outputs": "systemd/journal" # Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd
   "enable-v2": "true" # enable v2 API to stay compatible with previous etcd 3.3.x (needed for flannel e.g.)
+  "discovery-srv": "" # Discovery domain to enable DNS SRV discovery, leave empty to disable. If set, will override initial-cluster.
 
 # Certificate authority and certificate files for etcd
 etcd_certificates:

--- a/templates/etc/systemd/system/etcd.service.j2
+++ b/templates/etc/systemd/system/etcd.service.j2
@@ -4,9 +4,10 @@
 {{hostvars[host]['ansible_hostname']}}=https://{{hostvars[host]['ansible_' + etcd_interface].ipv4.address}}:{{etcd_peer_port}}{% if not loop.last %},{% endif %}
 {%- endfor -%} 
 {%- endmacro -%}
-
+{%- if not etcd_settings['discovery-srv'] %}
 {%- set x=etcd_settings.__setitem__('initial-cluster',cluster_hosts()) -%}
-
+{%- set x=etcd_settings.__delitem__('discovery-srv') -%}
+{%- endif %}
 [Unit]
 Description=etcd
 Documentation=https://github.com/coreos


### PR DESCRIPTION
Defaulting to false, this variable can be set to the domain name for
automatic etcd DNS SRV discovery.