### PR TITLE
New variable `etcd_systemd_timeout_start_sec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ etcd_architecture: "amd64"
 # Only change this if the architecture you are using is unsupported (for example: arm64)
 # For more information, see this: https://github.com/etcd-io/website/blob/master/content/docs/v3.4/op-guide/supported-platform.md
 etcd_allow_unsupported_archs: false
+# Default value for systemd's TimeoutStartSec option
+# Useful whith large etcd database files that take too long to load avoiding infinite restarts
+etcd_systemd_timeout_start_sec: "90s"
 
 etcd_settings:
   "name": "{{ansible_hostname}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,9 @@ etcd_architecture: "amd64"
 # Only change this if the architecture you are using is unsupported (for example: arm64)
 # For more information, see this: https://github.com/etcd-io/website/blob/master/content/docs/v3.4/op-guide/supported-platform.md
 etcd_allow_unsupported_archs: false
+# Default value for systemd's TimeoutStartSec option
+# Useful whith large etcd database files that take too long to load avoiding infinite restarts
+etcd_systemd_timeout_start_sec: "90s"
 
 etcd_settings:
   "name": "{{ansible_hostname}}"

--- a/templates/etc/systemd/system/etcd.service.j2
+++ b/templates/etc/systemd/system/etcd.service.j2
@@ -20,6 +20,7 @@ ExecStart={{etcd_bin_dir}}/etcd \
 {%- for setting in etcd_settings|sort %}
   --{{setting}}="{{etcd_settings[setting]}}" {% if not loop.last %}\{% endif %}
 {%- endfor %}
+TimeoutStartSec={{ etcd_systemd_timeout_start_sec }}
 Restart=on-failure
 RestartSec=5
 Type=notify


### PR DESCRIPTION
Without this option and with large databases, systemd will kill and restart the etcd process indefinitely before it could read and load all the database file.