### PR TITLE
SRE-880 Restart etcd on certificate change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: restart etcd
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+    name: etcd
+    state: restarted
+
 - name: reload systemd
   systemd:
     daemon_reload: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,8 @@
     group: root
   with_items:
     - "{{ etcd_certificates }}"
+  notify:
+    - restart etcd
   no_log: true
   tags:
     - etcd


### PR DESCRIPTION
Etcd does not automatically pickup changes to CA certificates. This commits adds an automatic restart step on certificate change.

See https://github.com/etcd-io/etcd/issues/11555 for context.